### PR TITLE
spdk: Use only even indexed cores as default configuration

### DIFF
--- a/contrib/nvmf_proxy-default
+++ b/contrib/nvmf_proxy-default
@@ -3,7 +3,7 @@
 # contains environment variables for /etc/systemd/system/nvmf_tgt.service
 
 # run on 4 cores out of 8 on SNIC
-CPU_MASK=0xf0
+CPU_MASK=0xaa
 # default config file
 NVMF_TGT_CONF=/etc/spdk/nvmf_proxy.conf
 


### PR DESCRIPTION
In < 4 cores smartnic, using CPU_MASK 0xF0 causes SPDK
application to malfunction. We can use the even cores instead,
and still use at most half of the cores.

Tests:
- Build spdk.rpm and verify values in /etc/default/nvmf_proxy

Signed-off-by: Nitzan Carmi <nitzanc@mellanox.com>